### PR TITLE
bottom navigation bar

### DIFF
--- a/lib/core/routing/app_routes.dart
+++ b/lib/core/routing/app_routes.dart
@@ -1,5 +1,8 @@
 class AppRoutes {
   static const String splash = '/splash';
   static const String onboarding = '/onboarding';
+  static const String mainscreen = '/mainscreen';
   static const String home = '/home';
+  static const String search = '/search';
+  static const String favorite = '/favorite';
 }

--- a/lib/core/routing/generated_routes_config.dart
+++ b/lib/core/routing/generated_routes_config.dart
@@ -3,15 +3,24 @@
 import 'package:go_router/go_router.dart';
 import 'package:go_transitions/go_transitions.dart';
 import 'package:theme_app/core/routing/app_routes.dart';
+import 'package:theme_app/features/home/views/favorite_view.dart';
 import 'package:theme_app/features/home/views/home_view.dart';
+import 'package:theme_app/features/home/views/main_view.dart';
+import 'package:theme_app/features/home/views/search_view.dart';
 import 'package:theme_app/features/onboarding/views/onboarding_view.dart';
 import 'package:theme_app/features/splash/views/splash_view.dart';
 
 class GeneratedRoutesConfig {
   static GoRouter router() {
     return GoRouter(
-      initialLocation: AppRoutes.splash,
+      initialLocation: AppRoutes.mainscreen,
       routes: [
+        GoRoute(
+          path: AppRoutes.mainscreen,
+          name: AppRoutes.mainscreen,
+          builder: (context, state) => const MainView(),
+          pageBuilder: GoTransitions.fadeUpwards,
+        ),
         GoRoute(
           path: AppRoutes.splash,
           name: AppRoutes.splash,
@@ -24,11 +33,23 @@ class GeneratedRoutesConfig {
           builder: (context, state) => const OnboardingView(),
           pageBuilder: GoTransitions.fadeUpwards,
         ),
+
         GoRoute(
           path: AppRoutes.home,
           name: AppRoutes.home,
           builder: (context, state) => HomeScreen(),
           pageBuilder: GoTransitions.fadeUpwards,
+        ),
+        GoRoute(
+          path: AppRoutes.search,
+          name: AppRoutes.search,
+          builder: (context, state) => const SearchView(),
+        ),
+
+        GoRoute(
+          path: AppRoutes.favorite,
+          name: AppRoutes.favorite,
+          builder: (context, state) => const FavoriteView(),
         ),
         // Add more routes
       ],

--- a/lib/features/home/views/favorite_view.dart
+++ b/lib/features/home/views/favorite_view.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class FavoriteView extends StatelessWidget {
+  const FavoriteView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(body: Center(child: Text("Favorite")));
+  }
+}

--- a/lib/features/home/views/home_view.dart
+++ b/lib/features/home/views/home_view.dart
@@ -12,7 +12,7 @@ class HomeScreen extends StatelessWidget {
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.background,
       appBar: AppBar(
-        title: Text("Food App"),
+        title: const Text("theme and more "),
         centerTitle: false,
         actions: [
           IconButton(
@@ -20,11 +20,12 @@ class HomeScreen extends StatelessWidget {
               Icons.dark_mode,
               color: Theme.of(context).iconTheme.color,
             ),
-            onPressed: Provider.of<ThemeProvider>(context).toggleTheme,
+            onPressed:
+                Provider.of<ThemeProvider>(context, listen: false).toggleTheme,
           ),
         ],
       ),
-      body: Center(child: Text("Welcome")),
+      body: Center(child: Text('main screen ')),
     );
   }
 }

--- a/lib/features/home/views/main_view.dart
+++ b/lib/features/home/views/main_view.dart
@@ -1,0 +1,62 @@
+// ignore_for_file: unused_element
+
+import 'package:flutter/material.dart';
+import 'package:theme_app/features/home/views/favorite_view.dart';
+import 'package:theme_app/features/home/views/home_view.dart';
+import 'package:theme_app/features/home/views/search_view.dart';
+
+class MainView extends StatefulWidget {
+  const MainView({super.key});
+
+  @override
+  State<MainView> createState() => _MainViewState();
+}
+
+class _MainViewState extends State<MainView> {
+  int _index = 0;
+
+  final List<Widget> _pages = [
+    const HomeScreen(),
+    const SearchView(),
+    const FavoriteView(),
+  ];
+
+  void _tabToggle(int index) {
+    setState(() {
+      _index = index;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: _pages[_index],
+
+      // FAB in center and floating above navbar
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => _tabToggle(1), // Index of center (search)
+        child: const Icon(Icons.search),
+      ),
+      floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
+
+      bottomNavigationBar: BottomAppBar(
+        shape: const CircularNotchedRectangle(),
+        notchMargin: 8,
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceAround,
+          children: [
+            IconButton(
+              icon: Icon(_index == 0 ? Icons.home : Icons.home_outlined),
+              onPressed: () => _tabToggle(0),
+            ),
+            const SizedBox(width: 48), // space for floating action button
+            IconButton(
+              icon: Icon(_index == 2 ? Icons.person : Icons.person_outline),
+              onPressed: () => _tabToggle(2),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/home/views/search_view.dart
+++ b/lib/features/home/views/search_view.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class SearchView extends StatelessWidget {
+  const SearchView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(body: Center(child: Text("Search")));
+  }
+}

--- a/lib/features/splash/views/splash_view.dart
+++ b/lib/features/splash/views/splash_view.dart
@@ -21,7 +21,7 @@ class _SplashViewState extends State<SplashView> {
   @override
   void initState() {
     super.initState();
-    _timer = Timer(const Duration(seconds: 5), () {
+    _timer = Timer(const Duration(seconds: 2), () {
       if (mounted) {
         context.go('/onboarding');
       }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -41,6 +41,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  convex_bottom_bar:
+    dependency: "direct main"
+    description:
+      name: convex_bottom_bar
+      sha256: ebf0f3deb1e8e99374d844fee7485d2980ec502dedfaad395c12118477933aef
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -112,6 +120,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.8.1"
+  google_nav_bar:
+    dependency: "direct main"
+    description:
+      name: google_nav_bar
+      sha256: bb12dd21514ee1b041ab3127673e2fd85e693337df308f7f2b75cd1e8e92eaf4
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.7"
   leak_tracker:
     dependency: transitive
     description:
@@ -200,6 +216,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.5"
+  salomon_bottom_bar:
+    dependency: "direct main"
+    description:
+      name: salomon_bottom_bar
+      sha256: e20abf2e449749432223a8b4e6647c212eef6c2b638e0ed8cc92eff9529c2b48
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.3.2"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,7 @@ environment:
 # the latest version available on pub.dev. To see which dependencies have newer
 # versions available, run `flutter pub outdated`.
 dependencies:
+  convex_bottom_bar: ^3.2.0
   cupertino_icons: ^1.0.8
   flutter:
     sdk: flutter
@@ -35,7 +36,9 @@ dependencies:
   gap: ^3.0.1
   go_router: ^15.1.2
   go_transitions: ^0.8.1
+  google_nav_bar: ^5.0.7
   provider: ^6.1.5
+  salomon_bottom_bar: ^3.3.2
 
 dev_dependencies:
   flutter_lints: ^5.0.0


### PR DESCRIPTION
## Summary by Sourcery

Set up a bottom navigation layout with MainView and associated routes, streamline splash timing, refine HomeScreen UI and theme toggle, and integrate new bottom bar packages

New Features:
- Introduce MainView with bottom navigation bar and floating action button to navigate between Home, Search, and Favorite tabs
- Add SearchView and FavoriteView pages
- Register new '/mainscreen', '/search', and '/favorite' routes and set initial route to the main screen

Enhancements:
- Shorten splash screen delay from 5 to 2 seconds
- Update HomeScreen app bar title, body text, and theme toggle invocation to use listen:false

Build:
- Add convex_bottom_bar, google_nav_bar, and salomon_bottom_bar dependencies